### PR TITLE
cimas sync 2026-07-08: rubocop todo inherit fix + release.yml bundle install

### DIFF
--- a/common/.github/workflows/docker.yml
+++ b/common/.github/workflows/docker.yml
@@ -14,6 +14,9 @@ on:
     types: [ metanorma/metanorma-docker ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-docker:
     uses: metanorma/ci/.github/workflows/sample-docker.yml@main

--- a/common/.github/workflows/generate.yml
+++ b/common/.github/workflows/generate.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/docker.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-docker:
     uses: metanorma/ci/.github/workflows/sample-gen.yml@main


### PR DESCRIPTION
## Summary

Cimas sync 2026-07-08 — master template corrections for two release-adjacent gaps:

1. **`.rubocop.yml`** — appended `.rubocop_todo.yml` as the last `inherit_from` entry so per-gem todos take effect against the shared oss-guides config. `inherit_from` is last-wins; the previous ordering left the shared config's stricter `Metrics/*` rules overriding per-gem grandfathering, and the todo became inert. Empirically verified on suma 2026-07-06: with the todo listed first, 34 `Metrics/*` offenses remained; moved last, cleared. Audit confirmed all 54 gems mapping this template already carry a live `.rubocop_todo.yml`, so this reference is safe to emit unconditionally. See [`metanorma/ci:a864ed9`](https://github.com/metanorma/ci/commit/a864ed9).

2. **`.github/workflows/release.yml`** — added explicit `release_command: | bundle install\n bundle exec rake release`, compensating for [`metanorma/ci#314`](https://github.com/metanorma/ci/issues/314)'s `bundler_cache` deprecation (hardcoded to `false` in the release job after the metanorma-cli v1.16.6 `Bundler::GemNotFound: metanorma-nist` incident). Without this override, the reusable's default `release_command: bundle exec rake release` fires against uninstalled gems and fails. Surfaced by [@kwkwan on metanorma-plugin-lutaml#285](https://github.com/metanorma/metanorma-plugin-lutaml/pull/285#discussion_r3517110963); deeper fix (`bundle install` inside `rubygems-release.yml`'s release job itself) tracked at [`metanorma/ci#349`](https://github.com/metanorma/ci/issues/349). See [`metanorma/ci:f994f4c`](https://github.com/metanorma/ci/commit/f994f4c).

## What to expect on your gem

- **If your gem's `.rubocop_todo.yml` covers current offenses**: CI stays green.
- **If your gem's `.rubocop_todo.yml` has plugin-drift** (missed cops from ci#334's `rubocop-rspec` / `rubocop-performance` / `rubocop-rake` addition, or subsequent minor releases of those plugins): CI will red on rubocop-style failures. Fix per-gem: `bundle exec rubocop --regenerate-todo` — same recipe as sts-ruby / suma on 2026-07-05.
- **`release.yml`** is template-only: no runtime effect until the gem's next release, at which point the two-line `release_command` kicks in and fixes the missing-bundle-install failure that was silent-broken before.

## Wave discipline

- `--flatten-stale` full auto-close of prior stale `cimas-sync-*` wave branches on this repo.
- Fortnightly cadence maintained; this is a scheduled sync, not an emergency.

🤖
